### PR TITLE
Remove npm version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
   ],
   "author": "Cameron Bytheway <bytheway.cameron@gmail.com>",
   "license": "MIT",
-  "engines": {
-    "npm": "~1.3.0"
-  },
   "dependencies": {
     "emitter-component": "~1.0.1"
   },


### PR DESCRIPTION
In there since initial commit 87b58a4b0.

There doesn't seem to be any particular value in that, but a clear warning is thrown at install-time:

```
npm WARN engine superagent-defaults@0.1.9: wanted: {"npm":"~1.3.0"} (current: {"node":"0.10.26","npm":"2.1.5"})
```
