### PR TITLE
add all methods support,include 3rd extension but not only set&auth

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -4,6 +4,7 @@
 
 var request = require('superagent');
 var methods = require('./methods');
+var protoMethods = Object.keys(request.Request.prototype);
 
 /**
  * Expose `Context`.
@@ -19,42 +20,37 @@ module.exports = Context;
 
 function Context(superagent) {
   if (!(this instanceof Context)) return new Context(superagent);
-  this.headers = [];
-  this.authCredentials = {};
   this.request = superagent || request;
+  this.stack = []; // store the default operation on the context
 }
 
-/**
- * Set default auth credentials
- *
- * @api public
- */
 
-Context.prototype.auth = function (user, pass) {
-  this.authCredentials.user = user;
-  this.authCredentials.pass = pass;
-};
+// setup methods for context
 
-/**
- * Add a default header to the context
- *
- * @api public
- */
+each(protoMethods, function(m) {
+  if (methods.indexOf(m) > -1) { // m is a HttpVerb method , don't record operation
+    return;
+  }
 
-Context.prototype.set = function() {
-  this.headers.push(arguments);
-  return this;
-};
+  Context.prototype[m] = function() {
+    this.stack.push({
+      method: m,
+      args: [].slice.call(arguments)
+    });
+
+    return this;
+  }
+});
 
 /**
- * Set the default headers on the req
+ * apply the operations on the context to real Request instance
  *
  * @api private
  */
 
-Context.prototype.applyHeaders = function(req) {
-  each(this.headers, function(header) {
-    req.set.apply(req, header);
+Context.prototype.applySatck = function(req) {
+  this.stack.forEach(function(op){ // op -> operation
+    req[op.method].apply(req,op.args);
   });
 };
 
@@ -66,15 +62,9 @@ each(methods, function(method){
   method = method.toUpperCase();
   Context.prototype[name] = function(url, fn){
     var req = this.request(method, url);
-    var auth = this.authCredentials;
 
     // Do the attaching here
-    this.applyHeaders(req);
-
-    // Call superagent's auth method
-    if(auth.hasOwnProperty('user') && auth.hasOwnProperty('pass')) {
-      req.auth(auth.user, auth.pass);
-    }
+    this.applySatck(req);
 
     // Tell the listeners we've created a new request
     this.emit('request', req);


### PR DESCRIPTION
add all methods support,include 3rd extension but not only set&auth

Since I wat to use [TooTallNate/superagent-proxy](https://github.com/TooTallNate/superagent-proxy) , and I can't find a way to set default proxy.
so this pr aims to support all methods on `superagent.Request.prototype`

