### PR TITLE
Npm is out of date.

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -48,7 +48,7 @@ each(protoMethods, function(m) {
  * @api private
  */
 
-Context.prototype.applySatck = function(req) {
+Context.prototype.applyStack = function(req) {
   this.stack.forEach(function(op){ // op -> operation
     req[op.method].apply(req,op.args);
   });
@@ -64,7 +64,7 @@ each(methods, function(method){
     var req = this.request(method, url);
 
     // Do the attaching here
-    this.applySatck(req);
+    this.applyStack(req);
 
     // Tell the listeners we've created a new request
     this.emit('request', req);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-defaults",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Create some defaults for superagent requests",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Npm is out of date with your last version. Doesn't have the 'applyStack' in context.js when you do a npm install. Increasing the package version and publishing to npm should fix this. I also included a small spelling fix.