### PR TITLE
fix an issue with supertest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - 0.8

--- a/lib/context.js
+++ b/lib/context.js
@@ -61,7 +61,13 @@ each(methods, function(method){
 
   method = method.toUpperCase();
   Context.prototype[name] = function(url, fn){
-    var req = this.request(method, url);
+    var req;
+    
+    if (this.request instanceof Function) {
+      req = this.request(method, url);
+    } else {
+      req = this.request[method.toLowerCase()](url);
+    }
 
     // Do the attaching here
     this.applyStack(req);


### PR DESCRIPTION
Workaround for: `TypeError: Property 'request' of object #<Context> is
not a function` described in a comment in issue #2

In supertest, request is no longer a function, but an object with
methods as its keys.

This check whether `this.request` is a Function. If so, do the usual,
otherwise assume it's an object.