### PR TITLE
Fix request events (`.on()`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ request
   });
 ```
 
+You can subscribe to `requestCreated`, which is emitted right after an [http method](lib/methods.js) is used,
+ before the XHR object is created.
+
+```js
+var defaults = require('superagent-defaults');
+var superagent = defaults();
+
+superagent
+  .set('my-default-header', 'my-default-value')
+  .auth('myUsername', 'myPassword')
+  .on('requestCreated', function (req) {
+    // you can modify the url
+    req.url = 'https://my-api-server.example.com' + req.url;
+  });
+
+superagent
+  .get('/my-api-path')
+  .on('request', function (req) {
+    console.log(req.url); // logs 'https://my-api-server.example.com/my-api-path'
+  })
+  .end();
+```
+
 Tests
 -----
 

--- a/component.js
+++ b/component.js
@@ -3,10 +3,3 @@
  */
 
 var Context = require('./lib/context');
-var Emitter = require('emitter');
-
-/**
- * Mixin the emitter
- */
-
-Emitter(Context.prototype);

--- a/component.json
+++ b/component.json
@@ -2,11 +2,10 @@
   "name": "superagent-defaults",
   "repo": "camshaft/superagent-defaults",
   "description": "Create some defaults for superagent requests",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "keywords": [],
   "dependencies": {
-    "visionmedia/superagent": "*",
-    "component/emitter": "*"
+    "visionmedia/superagent": "*"
   },
   "development": {},
   "license": "MIT",

--- a/index.js
+++ b/index.js
@@ -3,10 +3,3 @@
  */
 
 var Context = module.exports = require('./lib/context');
-var Emitter = require('emitter-component');
-
-/**
- * Mixin the emitter
- */
-
-Emitter(Context.prototype);

--- a/lib/context.js
+++ b/lib/context.js
@@ -68,7 +68,7 @@ each(methods, function(method) {
     this.applyStack(req);
 
     // Tell the listeners we've created a new request
-    this.emit('request', req);
+    req.emit && req.emit('requestCreated', req);
 
     fn && req.end(fn);
     return req;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-defaults",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "Create some defaults for superagent requests",
   "main": "index.js",
   "scripts": {
@@ -14,9 +14,6 @@
   ],
   "author": "Cameron Bytheway <bytheway.cameron@gmail.com>",
   "license": "MIT",
-  "dependencies": {
-    "emitter-component": "~1.0.1"
-  },
   "devDependencies": {
     "should": "~1.2.2",
     "mocha": "~1.11.0",

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -24,16 +24,6 @@ describe('superagent-context', function() {
     req.request()._headers.bar.should.equal(456);
   });
 
-  it('should emit `request` events', function(done) {
-    superagent
-      .on('request', function(req) {
-        req.url.should.eql('http://example.com/this/is/the/path');
-        done();
-      });
-
-    var req = superagent.get('http://example.com/this/is/the/path');
-  });
-
   it('should apply default auth', function() {
     superagent
       .auth('abc','cde');


### PR DESCRIPTION
- Don't use custom Emitter anymore.
- Fix `on` method which wasn't working.
- Rename custom event to `requestCreated` so that it doesn't collide with upstream's `request` event.

Fixes #13 